### PR TITLE
Fix license name and url in pom.xml (LGPL-2.1-only)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
   <url>http://www.indexdata.com/cql-java</url>
   <licenses>
     <license>
-      <name>LGPL</name>
-      <url>http://www.indexdata.com/licences/lgpl</url>
+      <name>LGPL-2.1-only</name>
+      <url>https://spdx.org/licenses/LGPL-2.1-only.html</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
The license entry in pom.xml has `<name>LGPL</name>`. This is ambiguous because there are several LGPL versions.

The README.md says "version 2.1 of the LGPL" so this should be changed to LGPL-2.1-only, the identifier suggested by https://spdx.org/licenses/

Only the entry in pom.xml is machine-readable, the README isn't, to help tools reading from pom.xml the change should be made.

The license entry in pom.xml contains
`<url>http://www.indexdata.com/licences/lgpl</url>`.

That URL redirects to
https://www.gnu.org/licenses/lgpl-3.0.en.html

To match the README it is changed to
`<url>https://spdx.org/licenses/LGPL-2.1-only.html</url>`.

Note: There also exists LGPL-2.1-or-later, the default suggested on
https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html
Regarding my contributions to cql-java:
I agree if cql-java is changed to LGPL-2.1-or-later.