### PR TITLE
Fix warning about reporting configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,6 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-site-plugin</artifactId>
               <version>3.6</version>
-              <configuration>
-              </configuration>
             </plugin>
           </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
         <version>2.10.4</version>
         <configuration>
           <chartset>UTF-8</chartset>
+          <additionalparam>${javadoc.opts}</additionalparam>
+          <reportPlugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+          </reportPlugins>
         </configuration>
       </plugin>
     </plugins>
@@ -159,15 +166,6 @@
               <artifactId>maven-site-plugin</artifactId>
               <version>3.6</version>
               <configuration>
-                <reportPlugins>
-                  <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                      <additionalparam>${javadoc.opts}</additionalparam>
-                    </configuration>
-                  </plugin>
-                </reportPlugins>
               </configuration>
             </plugin>
           </plugins>
@@ -199,4 +197,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,6 @@
         <configuration>
           <chartset>UTF-8</chartset>
           <additionalparam>${javadoc.opts}</additionalparam>
-          <reportPlugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-          </reportPlugins>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
 Fixes maven reporting:
```
    Some problems were encountered while building the effective model  for org.z3950.zing:cql-java:jar:1.14-SNAPSHOT
    [WARNING] Reporting configuration should be done in <reporting> section, not in maven-site-plugin <configuration> as reportPlugins parameter.
```