### PR TITLE
Retain escape sequences in lexer, fixes #5

### DIFF
--- a/src/main/java/org/z3950/zing/cql/CQLGenerator.java
+++ b/src/main/java/org/z3950/zing/cql/CQLGenerator.java
@@ -204,7 +204,7 @@ public class CQLGenerator {
     private String generate_term() {
 	switch (rnd.nextInt(10)) {
 	case 0: return "cat";
-	case 1: return "\\\"cat\\\"";
+	case 1: return "\"cat\\\"";  // A term with both bare quotes and escaped quotes
 	case 2: return "comp.os.linux";
 	case 3: return "xml:element";
 	case 4: return "<xml.element>";

--- a/src/main/java/org/z3950/zing/cql/CQLGenerator.java
+++ b/src/main/java/org/z3950/zing/cql/CQLGenerator.java
@@ -204,7 +204,7 @@ public class CQLGenerator {
     private String generate_term() {
 	switch (rnd.nextInt(10)) {
 	case 0: return "cat";
-	case 1: return "\"cat\"";
+	case 1: return "\\\"cat\\\"";
 	case 2: return "comp.os.linux";
 	case 3: return "xml:element";
 	case 4: return "<xml.element>";

--- a/src/main/java/org/z3950/zing/cql/CQLLexer.java
+++ b/src/main/java/org/z3950/zing/cql/CQLLexer.java
@@ -69,19 +69,15 @@ public class CQLLexer implements CQLTokenizer {
       //remember quote char
       char mark = c;
       qi++;
-      boolean escaped = false;
       buf.setLength(0); //reset buffer
-      while (qi < ql) {
-        if (!escaped && qs.charAt(qi) == mark) //terminator
-          break;
-        if (escaped && strchr("*?^\\", qs.charAt(qi))) //no escaping for d-quote
-          buf.append("\\");
-        if (!escaped && qs.charAt(qi) == '\\') { //escape-char
-          escaped = true;
+      while (qi < ql && qs.charAt(qi) != mark) {
+        if (qs.charAt(qi) == '\\') { //escape-char
+          if (qi == ql - 1) {
+            break; //unterminated
+          }
+          buf.append(qs.charAt(qi));
           qi++;
-          continue;
         }
-        escaped = false; //reset escape
         buf.append(qs.charAt(qi));
         qi++;
       }

--- a/src/main/java/org/z3950/zing/cql/CQLTermNode.java
+++ b/src/main/java/org/z3950/zing/cql/CQLTermNode.java
@@ -229,7 +229,7 @@ public class CQLTermNode extends CQLNode {
 	    str.indexOf('/') != -1 ||
 	    str.indexOf('(') != -1 ||
 	    str.indexOf(')') != -1) {
-	    str = '"' + str.replace("\"", "\\\"") + '"';
+	    str = '"' + str + '"';
 	}
 
 	return str;

--- a/src/main/java/org/z3950/zing/cql/CQLTermNode.java
+++ b/src/main/java/org/z3950/zing/cql/CQLTermNode.java
@@ -229,7 +229,7 @@ public class CQLTermNode extends CQLNode {
 	    str.indexOf('/') != -1 ||
 	    str.indexOf('(') != -1 ||
 	    str.indexOf(')') != -1) {
-	    str = '"' + str + '"';
+	    str = '"' + str.replaceAll("(?<!\\\\)\"", "\\\\\"") + '"';
 	}
 
 	return str;

--- a/src/test/resources/regression/06/03.xcql
+++ b/src/test/resources/regression/06/03.xcql
@@ -3,5 +3,5 @@
   <relation>
     <value>=</value>
   </relation>
-  <term>^cat says "fish"</term>
+  <term>^cat says \"fish\"</term>
 </searchClause>

--- a/src/test/resources/regression/06/06.xcql
+++ b/src/test/resources/regression/06/06.xcql
@@ -3,5 +3,5 @@
   <relation>
     <value>=</value>
   </relation>
-  <term>^cat*fishdog"horse?</term>
+  <term>^cat*fishdog\"horse?</term>
 </searchClause>

--- a/src/test/resources/regression/12/01.xcql
+++ b/src/test/resources/regression/12/01.xcql
@@ -3,5 +3,5 @@
   <relation>
     <value>=</value>
   </relation>
-  <term>term\*\?\^</term>
+  <term>te\rm\*\?\^</term>
 </searchClause>


### PR DESCRIPTION
Backslash (`\`) is preserved in Lexer, leaving it to later stages to decide what masking is to be used.

As is done with yaz and cql-go.

https://github.com/indexdata/cql-go/blob/84f3837d60305e690103051c0b52fc3ff4c32500/cql/lexer.go#L94
https://github.com/indexdata/cql-go/blob/84f3837d60305e690103051c0b52fc3ff4c32500/cql/cql.go#L281

Example of CQL query:

     "a\"b"

which was converted to:

    <term>a"b</term>

It is now converted to:

    <term>a\"b</term>

The same term without quotes are already preserved, eg:

     a\"b

becomes

    <term>a\"b</term>

So *existing* behavior was inconsistent WRT how " was treated.


