### PR TITLE
Proper fixup for " when generating CQL query

### DIFF
--- a/src/main/java/org/z3950/zing/cql/CQLLexer.java
+++ b/src/main/java/org/z3950/zing/cql/CQLLexer.java
@@ -18,6 +18,8 @@ public class CQLLexer implements CQLTokenizer {
     private String lval;
     private StringBuilder buf = new StringBuilder();
 
+    static final String OPS_AND_WHITESPACE = "()/<>= \t\r\n";
+
     public CQLLexer(String cql, boolean debug) {
         qs = cql;
         ql = cql.length();
@@ -89,8 +91,7 @@ public class CQLLexer implements CQLTokenizer {
         } else {
             what = TT_WORD;
             buf.setLength(0); // reset buffer
-            while (qi < ql
-                    && !strchr("()/<>= \t\r\n", qs.charAt(qi))) {
+            while (qi < ql && !strchr(OPS_AND_WHITESPACE, qs.charAt(qi))) {
                 buf.append(qs.charAt(qi));
                 qi++;
             }

--- a/src/main/java/org/z3950/zing/cql/CQLTermNode.java
+++ b/src/main/java/org/z3950/zing/cql/CQLTermNode.java
@@ -223,24 +223,27 @@ public class CQLTermNode extends CQLNode {
     }
 
     static String maybeQuote(String str) {
-        if (str == null)
+        if (str == null) {
             return null;
-
-        // There _must_ be a better way to make this test ...
-        if (str.length() == 0 ||
-                str.indexOf('"') != -1 ||
-                str.indexOf(' ') != -1 ||
-                str.indexOf('\t') != -1 ||
-                str.indexOf('=') != -1 ||
-                str.indexOf('<') != -1 ||
-                str.indexOf('>') != -1 ||
-                str.indexOf('/') != -1 ||
-                str.indexOf('(') != -1 ||
-                str.indexOf(')') != -1) {
-            str = '"' + str.replaceAll("(?<!\\\\)\"", "\\\\\"") + '"';
         }
-
-        return str;
+        boolean quote = str.isEmpty();
+        boolean escaped = false;
+        StringBuilder sb = new StringBuilder();
+        for (char ch : str.toCharArray()) {
+            if (CQLLexer.OPS_AND_WHITESPACE.indexOf(ch) >= 0) {
+                quote = true;
+            }
+            if (ch == '"' && !escaped) {
+                sb.append('\\');
+            }
+            escaped = ch == '\\' && !escaped;
+            sb.append(ch);
+        }
+        if (quote) {
+            return "\"" + sb.toString() + "\"";
+        } else {
+            return sb.toString();
+        }
     }
 
     @Override

--- a/src/main/java/org/z3950/zing/cql/CQLTermNode.java
+++ b/src/main/java/org/z3950/zing/cql/CQLTermNode.java
@@ -242,6 +242,10 @@ public class CQLTermNode extends CQLNode {
             escaped = ch == '\\' && !escaped;
             sb.append(ch);
         }
+        if (escaped) {
+            // trailing backslash - escape it
+            sb.append('\\');
+        }
         if (quote) {
             return "\"" + sb.toString() + "\"";
         } else {

--- a/src/main/java/org/z3950/zing/cql/CQLTermNode.java
+++ b/src/main/java/org/z3950/zing/cql/CQLTermNode.java
@@ -78,8 +78,8 @@ public class CQLTermNode extends CQLNode {
 
     @Override
     public String toCQL() {
-        String quotedIndex = maybeQuote(index);
-        String quotedTerm = maybeQuote(term);
+        String quotedIndex = toCQLTerm(index);
+        String quotedTerm = toCQLTerm(term);
         String res = quotedTerm;
 
         if (index != null &&
@@ -192,7 +192,7 @@ public class CQLTermNode extends CQLNode {
         if (isResultSetIndex(index)) {
             // Special case: ignore relation, modifiers, wildcards, etc.
             // There's parallel code in toType1BER()
-            return "@set " + maybeQuote(term);
+            return "@set " + toCQLTerm(term);
         }
 
         List<String> attrs = getAttrs(config);
@@ -219,10 +219,13 @@ public class CQLTermNode extends CQLNode {
             text = text.substring(0, len - 1);
         }
 
-        return s + maybeQuote(text);
+        return s + toCQLTerm(text);
     }
 
-    static String maybeQuote(String str) {
+    // ensure that a term is properly quoted for CQL output if necessary.
+    // If the term has a bare double-quote (") it will be
+    // escaped with a backslash.
+    static String toCQLTerm(String str) {
         if (str == null) {
             return null;
         }

--- a/src/test/java/org/z3950/zing/cql/CQLTermNodeTest.java
+++ b/src/test/java/org/z3950/zing/cql/CQLTermNodeTest.java
@@ -1,0 +1,52 @@
+package org.z3950.zing.cql;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CQLTermNodeTest {
+    @Test
+    public void TestMaybeQuoteNull() {
+        assertNull(CQLTermNode.maybeQuote(null));
+    }
+
+    @Test
+    public void TestMaybeQuoteEmpty() {
+        assertEquals("\"\"", CQLTermNode.maybeQuote(""));
+    }
+
+    @Test
+    public void TestMaybeQuoteRelation() {
+        assertEquals("\"<\"", CQLTermNode.maybeQuote("<"));
+    }
+
+    @Test
+    public void TestMaybeQuoteSimple() {
+        assertEquals("simple", CQLTermNode.maybeQuote("simple"));
+    }
+
+    @Test
+    public void TestMaybeQuoteBlank() {
+        assertEquals("\"a b\"", CQLTermNode.maybeQuote("a b"));
+    }
+
+    @Test
+    public void TestMaybeQuoteQuote1() {
+        assertEquals("a\\\"", CQLTermNode.maybeQuote("a\""));
+    }
+
+    @Test
+    public void TestMaybeQuoteQuote2() {
+        assertEquals("a\\\"", CQLTermNode.maybeQuote("a\\\""));
+    }
+
+    @Test
+    public void TestMaybeQuoteQuote3() {
+        assertEquals("a" + "\\\\" + "\\\"", CQLTermNode.maybeQuote("a" + "\\\\" + "\""));
+    }
+
+    @Test
+    public void TestMaybeQuoteQuote4() {
+        assertEquals("a" + "\\\\" + "\\\"", CQLTermNode.maybeQuote("a" + "\\\\" + "\\\""));
+    }
+
+}

--- a/src/test/java/org/z3950/zing/cql/CQLTermNodeTest.java
+++ b/src/test/java/org/z3950/zing/cql/CQLTermNodeTest.java
@@ -50,8 +50,13 @@ public class CQLTermNodeTest {
     }
 
     @Test
-    public void TestTCQLTermQuoteBackSlashTrail() {
-        assertEquals("a\\", CQLTermNode.toCQLTerm("a\\"));
+    public void TestTCQLTermQuoteBackSlashTrail1() {
+        assertEquals("a\\\\", CQLTermNode.toCQLTerm("a\\"));
+    }
+
+    @Test
+    public void TestTCQLTermQuoteBackSlashTrail2() {
+        assertEquals("\"a \\\\\"", CQLTermNode.toCQLTerm("a \\"));
     }
 
 }

--- a/src/test/java/org/z3950/zing/cql/CQLTermNodeTest.java
+++ b/src/test/java/org/z3950/zing/cql/CQLTermNodeTest.java
@@ -5,48 +5,53 @@ import static org.junit.Assert.*;
 
 public class CQLTermNodeTest {
     @Test
-    public void TestMaybeQuoteNull() {
-        assertNull(CQLTermNode.maybeQuote(null));
+    public void TestTCQLTermQuoteNull() {
+        assertNull(CQLTermNode.toCQLTerm(null));
     }
 
     @Test
-    public void TestMaybeQuoteEmpty() {
-        assertEquals("\"\"", CQLTermNode.maybeQuote(""));
+    public void TestTCQLTermQuoteEmpty() {
+        assertEquals("\"\"", CQLTermNode.toCQLTerm(""));
     }
 
     @Test
-    public void TestMaybeQuoteRelation() {
-        assertEquals("\"<\"", CQLTermNode.maybeQuote("<"));
+    public void TestTCQLTermQuoteRelation() {
+        assertEquals("\"<\"", CQLTermNode.toCQLTerm("<"));
     }
 
     @Test
-    public void TestMaybeQuoteSimple() {
-        assertEquals("simple", CQLTermNode.maybeQuote("simple"));
+    public void TestTCQLTermQuoteSimple() {
+        assertEquals("simple", CQLTermNode.toCQLTerm("simple"));
     }
 
     @Test
-    public void TestMaybeQuoteBlank() {
-        assertEquals("\"a b\"", CQLTermNode.maybeQuote("a b"));
+    public void TestTCQLTermQuoteBlank() {
+        assertEquals("\"a b\"", CQLTermNode.toCQLTerm("a b"));
     }
 
     @Test
-    public void TestMaybeQuoteQuote1() {
-        assertEquals("a\\\"", CQLTermNode.maybeQuote("a\""));
+    public void TestTCQLTermQuoteQuote1() {
+        assertEquals("a\\\"", CQLTermNode.toCQLTerm("a\""));
     }
 
     @Test
-    public void TestMaybeQuoteQuote2() {
-        assertEquals("a\\\"", CQLTermNode.maybeQuote("a\\\""));
+    public void TestTCQLTermQuoteQuote2() {
+        assertEquals("a\\\"", CQLTermNode.toCQLTerm("a\\\""));
     }
 
     @Test
-    public void TestMaybeQuoteQuote3() {
-        assertEquals("a" + "\\\\" + "\\\"", CQLTermNode.maybeQuote("a" + "\\\\" + "\""));
+    public void TestTCQLTermQuoteQuote3() {
+        assertEquals("a" + "\\\\" + "\\\"", CQLTermNode.toCQLTerm("a" + "\\\\" + "\""));
     }
 
     @Test
-    public void TestMaybeQuoteQuote4() {
-        assertEquals("a" + "\\\\" + "\\\"", CQLTermNode.maybeQuote("a" + "\\\\" + "\\\""));
+    public void TestTCQLTermQuoteQuote4() {
+        assertEquals("a" + "\\\\" + "\\\"", CQLTermNode.toCQLTerm("a" + "\\\\" + "\\\""));
+    }
+
+    @Test
+    public void TestTCQLTermQuoteBackSlashTrail() {
+        assertEquals("a\\", CQLTermNode.toCQLTerm("a\\"));
     }
 
 }


### PR DESCRIPTION
The replaceAll for looking back whether the " was escaped did not work as the preceding backslash could have been the result of escaping a backslash itself.

A follow up for #5